### PR TITLE
Force --format=gztar when calling sdist

### DIFF
--- a/aldryn_client/upload/addon.py
+++ b/aldryn_client/upload/addon.py
@@ -19,7 +19,7 @@ def package_addon(path):
     temp_dir = create_temp_dir()
     with dev_null() as devnull:
         subprocess.check_call(
-            ['python', 'setup.py', 'sdist', '-d', temp_dir],
+            ['python', 'setup.py', 'sdist', '-d', temp_dir, '--format=gztar'],
             cwd=path, stdout=devnull,
         )
     for filename in os.listdir(temp_dir):


### PR DESCRIPTION
This is required on Windows for 'aldryn addon upload' to work. Windows defaults to 'zip' format on sdist, breaking the rest of the flow.
