### PR TITLE
divio project commands without local checkout

### DIFF
--- a/divio_cli/cli.py
+++ b/divio_cli/cli.py
@@ -196,16 +196,6 @@ def project_list(obj, grouped):
     click.echo_via_pager(output)
 
 
-# @project.command(name='info')
-# @click.argument('slug')
-# @click.pass_obj
-# def project_info(obj, slug):
-#     """Show info about a project"""
-#     # TODO: proper formatting
-#     website_id = obj.get_website_id_for_slug(slug)
-#     click.echo(obj.get_project(website_id))
-
-
 @project.command(name='deploy')
 @click.argument('stage', default='test')
 @click.pass_obj

--- a/divio_cli/localdev/utils.py
+++ b/divio_cli/localdev/utils.py
@@ -12,13 +12,13 @@ from .. import settings
 from .. import config
 
 
-def get_aldryn_project_settings(path=None):
-    project_home = get_project_home(path)
+def get_aldryn_project_settings(path=None, silent=False):
+    project_home = get_project_home(path, silent=silent)
     with open(os.path.join(project_home, settings.ALDRYN_DOT_FILE)) as fh:
         return json.load(fh)
 
 
-def get_project_home(path=None):
+def get_project_home(path=None, silent=False):
     """
     find project root by traversing up the tree looking for
     the '.aldryn' file
@@ -37,7 +37,8 @@ def get_project_home(path=None):
         # traversing up the tree
         previous_path = current_path
         current_path = os.path.abspath(os.path.join(current_path, os.pardir))
-
+    if silent:
+        return
     raise click.ClickException(
         "Divio Cloud project file '.aldryn' could not be found! Please make "   # FIXME: Rename
         "sure you're in a Divio Cloud project folder and the file exists."

--- a/divio_cli/utils.py
+++ b/divio_cli/utils.py
@@ -182,11 +182,8 @@ def open_project_cloud_site(client, stage):
         click.secho('No {} server deployed yet.'.format(stage), fg='yellow')
 
 
-def get_cp_url(client, section='dashboard'):
-    from .localdev.utils import get_aldryn_project_settings
-
-    project_settings = get_aldryn_project_settings()
-    project_data = client.get_project(project_settings['id'])
+def get_cp_url(client, project, section='dashboard'):
+    project_data = client.get_project(project['id'])
     url = project_data['dashboard_url']
 
     if section != 'dashboard':
@@ -324,3 +321,38 @@ def print_package_renamed_warning():
     click.secho(message, fg='red')
     hr(char='=', fg='red')
     click.echo('')
+
+
+class Map(dict):
+    """
+    A dictionary which also allows accessing values by dot notation.
+    Example:
+    m = Map({'first_name': 'Eduardo'}, last_name='Pool', age=24, sports=['Soccer'])
+    """
+    def __init__(self, *args, **kwargs):
+        super(Map, self).__init__(*args, **kwargs)
+        for arg in args:
+            if isinstance(arg, dict):
+                for k, v in arg.iteritems():
+                    self[k] = v
+
+        if kwargs:
+            for k, v in kwargs.iteritems():
+                self[k] = v
+
+    def __getattr__(self, attr):
+        return self.get(attr)
+
+    def __setattr__(self, key, value):
+        self.__setitem__(key, value)
+
+    def __setitem__(self, key, value):
+        super(Map, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
+
+    def __delattr__(self, item):
+        self.__delitem__(item)
+
+    def __delitem__(self, key):
+        super(Map, self).__delitem__(key)
+        del self.__dict__[key]

--- a/divio_cli/utils.py
+++ b/divio_cli/utils.py
@@ -169,12 +169,9 @@ def check_output(*popenargs, **kwargs):
     return execute(subprocess.check_output, *popenargs, **kwargs).decode()
 
 
-def open_project_cloud_site(client, stage):
-    from .localdev.utils import get_aldryn_project_settings
-
+def open_project_cloud_site(client, project, stage):
     assert stage in ('test', 'live')
-    project_settings = get_aldryn_project_settings()
-    project_data = client.get_project(project_settings['id'])
+    project_data = client.get_project(project['id'])
     url = project_data['{}_status'.format(stage)]['site_url']
     if url:
         click.launch(url)
@@ -321,6 +318,15 @@ def print_package_renamed_warning():
     click.secho(message, fg='red')
     hr(char='=', fg='red')
     click.echo('')
+
+
+def check_project_context(project):
+    if 'id' not in project:
+        raise click.ClickException(
+            'This command requires a Divio Cloud Project id. Please provide '
+            'one with the --id option or call the command from a project '
+            'directory (with a .aldryn file).'
+        )
 
 
 class Map(dict):


### PR DESCRIPTION
Allow calling some "divio project" commands without a local checkout of the
sourcecode with a .aldryn file. Instead allow passing in the  id of the
Project with --id.

Also fixes a few errors with the deploy command.