### PR TITLE
env var for custom docker brige gateway

### DIFF
--- a/divio_cli/localdev/main.py
+++ b/divio_cli/localdev/main.py
@@ -817,6 +817,7 @@ def open_project(open_browser=True):
             proto, host_port = os.environ.get('DOCKER_HOST').split('://')
             host = host_port.split(':')[0]
 
+    host = os.environ.get('DOCKER_BRIDGE_GATEWAY') or host
     addr = 'http://{}:{}/'.format(host, port)
 
     click.secho(


### PR DESCRIPTION
this allows one to override the default gateway derived from the `DOCKER_HOST` env var. Especially useful in customized setup, e.g. with Docker in Docker.