### PR TITLE
Fixed project id override for remote commands

### DIFF
--- a/divio_cli/localdev/utils.py
+++ b/divio_cli/localdev/utils.py
@@ -172,3 +172,34 @@ class DockerComposeConfig(object):
             data = mount.split(':')
             if data[1] == remote_path:
                 return True
+
+
+def allow_remote_id_override(func):
+    """Adds an identifier option to the command, and gets the proper id"""
+
+    def read_remote_id(remote_id, *args, **kwargs):
+        ERROR_MSG = (
+            'This command requires a Divio Cloud Project id. Please '
+            'provide one with the --remote-id option or call the '
+            'command from a project directory (with a .aldryn file).'
+        )
+
+        if not remote_id:
+            try:
+                remote_id = get_aldryn_project_settings(silent=True)['id']
+            except KeyError:
+                raise click.ClickException(ERROR_MSG)
+            else:
+                if not remote_id:
+                    raise click.ClickException(ERROR_MSG)
+        return func(remote_id, *args, **kwargs)
+
+    return click.option(
+        '--remote-id',
+        'remote_id',
+        default=None,
+        type=int,
+        help='Remote Project ID to use for project commands. '
+             'Defaults to the project in the current directory using the '
+             '.aldryn file.'
+    )(read_remote_id)

--- a/divio_cli/utils.py
+++ b/divio_cli/utils.py
@@ -170,9 +170,9 @@ def check_output(*popenargs, **kwargs):
     return execute(subprocess.check_output, *popenargs, **kwargs).decode()
 
 
-def open_project_cloud_site(client, project, stage):
+def open_project_cloud_site(client, project_id, stage):
     assert stage in ('test', 'live')
-    project_data = client.get_project(project['id'])
+    project_data = client.get_project(project_id)
     url = project_data['{}_status'.format(stage)]['site_url']
     if url:
         click.launch(url)
@@ -180,8 +180,8 @@ def open_project_cloud_site(client, project, stage):
         click.secho('No {} server deployed yet.'.format(stage), fg='yellow')
 
 
-def get_cp_url(client, project, section='dashboard'):
-    project_data = client.get_project(project['id'])
+def get_cp_url(client, project_id, section='dashboard'):
+    project_data = client.get_project(project_id)
     url = project_data['dashboard_url']
 
     if section != 'dashboard':
@@ -323,15 +323,6 @@ def print_package_renamed_warning():
 
 def json_dumps_unicode(d, **kwargs):
     return json.dumps(d, ensure_ascii=False, **kwargs).encode('utf-8')
-
-
-def check_project_context(project):
-    if 'id' not in project:
-        raise click.ClickException(
-            'This command requires a Divio Cloud Project id. Please provide '
-            'one with the --id option or call the command from a project '
-            'directory (with a .aldryn file).'
-        )
 
 
 class Map(dict):


### PR DESCRIPTION
Fixed project id override for remote commands, which was not working properly for several commands.
Refactored into a decorator to allow easier attachment into new commands.
Removed option from commands that didn't need it, to avoid confusion with users.
Renamed option to --remote-id to clarify the actual effect of the id.