### PR TITLE
Fix open mode deprecated in Python 3.11

### DIFF
--- a/divio_cli/localdev/main.py
+++ b/divio_cli/localdev/main.py
@@ -920,7 +920,7 @@ def develop_package(package, no_rebuild=False):
     requirements_file = os.path.join(project_home, "requirements.in")
     # open file with 'universal newline support'
     # https://docs.python.org/2/library/functions.html#open
-    with open(requirements_file, "rU") as fh:
+    with open(requirements_file, "r") as fh:
         addons = fh.readlines()
 
     replaced = False


### PR DESCRIPTION
[Python 3.11 deprecated the `U` flag](https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11) when setting the mode in several file handling methods:

> [open()](https://docs.python.org/3/library/functions.html#open), [io.open()](https://docs.python.org/3/library/io.html#io.open), [codecs.open()](https://docs.python.org/3/library/codecs.html#codecs.open) and [fileinput.FileInput](https://docs.python.org/3/library/fileinput.html#fileinput.FileInput) no longer accept 'U' (“universal newline”) in the file mode. In Python 3, “universal newline” mode is used by default whenever a file is opened in text mode, and the 'U' flag has been deprecated since Python 3.3. The [newline parameter](https://docs.python.org/3/library/functions.html#open-newline-parameter) to these functions controls how universal newlines work. (Contributed by Victor Stinner in [bpo-37330](https://bugs.python.org/issue?@action=redirect&bpo=37330).) 

This PR removes that flag where it was used in the `divio app develop` command.